### PR TITLE
Check user by github organisation membership

### DIFF
--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -195,8 +195,9 @@ class GitHubOrgOAuthenticator(GitHubOAuthenticator):
             org_users.extend(u['login'] for u in users)
 
             try:
-                links = r.headers['Link'].split(',')
+                current = r
                 r = None
+                links = current.headers['Link'].split(',')
                 for link in links:
                     m = re.match('<([^>]+)>;\s*rel="(\w+)"', link.strip())
                     try:

--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -128,7 +128,9 @@ class GitHubOrgOAuthenticator(GitHubOAuthenticator):
 
     @gen.coroutine
     def check_whitelist(self, username):
-        found = super().check_whitelist(username)
+        # No whitelist means any name is allowed, disable this:
+        # https://github.com/jupyterhub/jupyterhub/blob/0.7.2/jupyterhub/auth.py#L148
+        found = self.whitelist and super().check_whitelist(username)
         if not found and self.organisation_whitelist:
             (org_users, etag) = yield self._get_github_org_members_async(
                 self.organisation_whitelist, self.github_organisation_etag)

--- a/oauthenticator/tests/test_github_openmicroscopy.py
+++ b/oauthenticator/tests/test_github_openmicroscopy.py
@@ -1,0 +1,18 @@
+from pytest import mark
+
+from ..github import GitHubOrgOAuthenticator
+
+#import logging
+#logging.basicConfig(level=logging.DEBUG)
+
+
+@mark.gen_test
+@mark.parametrize("username,ismember", [
+    ('not-in-org', False),
+    ('jrswedlow', True),
+])
+def test_check_whitelist(username, ismember):
+    authenticator = GitHubOrgOAuthenticator()
+    authenticator.organisation_whitelist = 'openmicroscopy'
+    found = yield authenticator.check_whitelist(username)
+    assert found == ismember

--- a/oauthenticator/tests/test_github_openmicroscopy.py
+++ b/oauthenticator/tests/test_github_openmicroscopy.py
@@ -13,6 +13,6 @@ from ..github import GitHubOrgOAuthenticator
 ])
 def test_check_whitelist(username, ismember):
     authenticator = GitHubOrgOAuthenticator()
-    authenticator.organisation_whitelist = 'openmicroscopy'
+    authenticator.github_organization_whitelist = ['openmicroscopy']
     found = yield authenticator.check_whitelist(username)
     assert found == ismember


### PR DESCRIPTION
I wrote this without realising there is already an upstream PR that implements a similar functionality in a different way (lists the organisations that a user belongs to, whereas this PR lists the users in an organisation) https://github.com/jupyterhub/oauthenticator/pull/58

There's currently a problem with it: https://github.com/jupyterhub/oauthenticator/pull/58#issuecomment-290442794

so I propose we temporarily use my changes in the IDR until the upstream PR is released.