### PR TITLE
Multiple github oauth tokens

### DIFF
--- a/oauthenticator/github.py
+++ b/oauthenticator/github.py
@@ -69,8 +69,8 @@ class GitHubOAuthenticator(OAuthenticator):
         
         # GitHub specifies a POST request yet requires URL parameters
         params = dict(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
+            client_id=self.get_client_id(handler),
+            client_secret=self.get_client_secret(handler),
             code=code
         )
         
@@ -167,9 +167,12 @@ class GitHubOrgOAuthenticator(GitHubOAuthenticator):
                  Usernames are lower-cased.
         """
         http_client = AsyncHTTPClient()
+        # We don't have a handler object in this method so this will return
+        # the default client_* which is fine because they should all be for
+        # the same owner
         params = dict(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
+            client_id=self.get_client_id(),
+            client_secret=self.get_client_secret(),
         )
         github_org_url = 'https://api.github.com/orgs/%s/members'
         fetch_url = url_concat(github_org_url % github_org, params)

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -39,7 +39,7 @@ class OAuthLoginHandler(BaseHandler):
         self.log.info('oauth redirect: %r', redirect_uri)
         self.authorize_redirect(
             redirect_uri=redirect_uri,
-            client_id=self.authenticator.client_id,
+            client_id=self.authenticator.get_client_id(self),
             scope=self.scope,
             response_type='code')
 

--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -13,7 +13,7 @@ from jupyterhub.handlers import BaseHandler
 from jupyterhub.auth import Authenticator
 from jupyterhub.utils import url_path_join
 
-from traitlets import Unicode, Bool
+from traitlets import Unicode, Bool, Dict
 
 
 def guess_callback_uri(protocol, host, hub_server_url):
@@ -97,6 +97,24 @@ class OAuthenticator(Authenticator):
         else:
             return True
 
+    oauth_callback_url_hostmap = Dict(
+        config=True,
+        help="""Map of hostname to oauth_callback_url. This allows jupyterhub
+        to run behind multiple hostnames"""
+    )
+
+    client_id_hostmap = Dict(
+        config=True,
+        help="""Map of hostname to client_id. This allows jupyterhub
+        to run behind multiple hostnames"""
+    )
+
+    client_secret_hostmap = Dict(
+        config=True,
+        help="""Map of hostname to client_secret. This allows jupyterhub
+        to run behind multiple hostnames"""
+    )
+
     def login_url(self, base_url):
         return url_path_join(base_url, 'oauth_login')
 
@@ -108,6 +126,10 @@ class OAuthenticator(Authenticator):
         
         Either from config or guess based on the current request.
         """
+        try:
+            return self.oauth_callback_url_hostmap[handler.request.host]
+        except (AttributeError, KeyError):
+            pass
         if self.oauth_callback_url:
             return self.oauth_callback_url
         elif handler:
@@ -118,6 +140,22 @@ class OAuthenticator(Authenticator):
             )
         else:
             raise ValueError("Specify callback oauth_callback_url or give me a handler to guess with")
+
+    def get_client_id(self, handler=None):
+        """Get OAuth client_id
+        """
+        try:
+            return self.client_id_hostmap[handler.request.host]
+        except (AttributeError, KeyError):
+            return self.client_id
+
+    def get_client_secret(self, handler=None):
+        """Get OAuth client_secret
+        """
+        try:
+            return self.client_secret_hostmap[handler.request.host]
+        except (AttributeError, KeyError):
+            return self.client_secret
 
     def get_handlers(self, app):
         return [

--- a/oauthenticator/tests/test_github.py
+++ b/oauthenticator/tests/test_github.py
@@ -1,8 +1,8 @@
 from pytest import fixture, mark
 
-from ..github import GitHubOAuthenticator
+from ..github import GitHubOAuthenticator, GitHubLoginHandler
 
-from .mocks import setup_oauth_mock, no_code_test
+from .mocks import setup_oauth_mock, no_code_test, mock_handler
 
 
 def user_model(username):
@@ -33,3 +33,33 @@ def test_github(github_client):
 @mark.gen_test
 def test_no_code(github_client):
     yield no_code_test(GitHubOAuthenticator())
+
+
+@mark.gen_test
+def test_github_multiple_tokens(github_client):
+    authenticator = GitHubOAuthenticator()
+    authenticator.client_id = 'id'
+    authenticator.client_id_hostmap = {
+        'a.example.org': 'ida',
+    }
+    authenticator.client_secret = 'secret'
+    authenticator.client_secret_hostmap = {
+        'a.example.org': 'secreta',
+    }
+    authenticator.oauth_callback_url = 'http://example.org/cb'
+    authenticator.oauth_callback_url_hostmap = {
+        'a.example.org': 'http://a.example.org/cba',
+    }
+
+    handler = github_client.handler_for_user(user_model('dummy'))
+    handler.request.host = 'a.example.org'
+
+    assert authenticator.get_client_id() == 'id'
+    assert authenticator.get_client_id(handler) == 'ida'
+    assert authenticator.get_client_secret() == 'secret'
+    assert authenticator.get_client_secret(handler) == 'secreta'
+    assert authenticator.get_callback_url() == 'http://example.org/cb'
+    assert authenticator.get_callback_url(handler) == \
+        'http://a.example.org/cba'
+
+    # NOTE: This doesn't test that these methods are called correctly


### PR DESCRIPTION
This allows multiple Github tokens to be specified, split by hostname. This means the same jupyterhub instance can run behind multiple external hostnames (e.g. `idr` and `idr-next`), and the `Host` header will be used to choose between different sets of OAuth tokens.

The existing `client_id` and `client_secret` parameters are still required, and are used if no host matches. e.g.
```
# Current parameters (used as defaults):
c.GitHubOAuthenticator.oauth_callback_url = "https://example.org/jupyter/hub/oauth_callback"
c.GitHubOAuthenticator.client_id = "00000000000000000000"
c.GitHubOAuthenticator.client_secret = "0000000000000000000000000000000000000000"

# Optional additional OAuth parameters
c.GitHubOAuthenticator.oauth_callback_url_hostmap = {
    "1.2.3.4": "https://1.2.3.4/jupyter/hub/oauth_callback",
    "localhost:8080": "http://localhost:8080/jupyter/hub/oauth_callback"
}
c.GitHubOAuthenticator.client_id_hostmap = {
    "1.2.3.4": "11111111111111111111",
    "localhost:8080": "22222222222222222222"
}
c.GitHubOAuthenticator.client_secret_hostmap = {
    "1.2.3.4": "1111111111111111111111111111111111111111",
    "localhost:8080": "2222222222222222222222222222222222222222"
}
```
