### PR TITLE
Pin jupyterhub to fix tests

### DIFF
--- a/oauthenticator/tests/test_github_openmicroscopy.py
+++ b/oauthenticator/tests/test_github_openmicroscopy.py
@@ -1,4 +1,5 @@
 from pytest import mark
+from os import getenv
 
 from ..github import GitHubOrgOAuthenticator
 
@@ -6,6 +7,12 @@ from ..github import GitHubOrgOAuthenticator
 #logging.basicConfig(level=logging.DEBUG)
 
 
+# This is likely to fail on Travis due to Github rate limits:
+# https://developer.github.com/v3/#rate-limiting
+@mark.xfail(
+    getenv('TRAVIS') == 'true',
+    reason="Travis exceeds Github API rate limits"
+)
 @mark.gen_test
 @mark.parametrize("username,ismember", [
     ('not-in-org', False),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-jupyterhub>=0.5
+# Upstream has modifications to work with jupyterhub 0.8
+# For now pin the jupyterhub version
+jupyterhub==0.7.2


### PR DESCRIPTION
Upstream has modifications to ensure compatibility with the latest jupyterhub. This pins the version of jupyterhub so this repo continues to work. In addition it disables a test which often fails due to exceeding Github API requests on travis.